### PR TITLE
2021-01-15  - no longer possible anymore

### DIFF
--- a/source/hassio/installation.markdown
+++ b/source/hassio/installation.markdown
@@ -187,11 +187,10 @@ curl -sL "https://raw.githubusercontent.com/home-assistant/supervised-installer/
 
 ## 또 다른 방법: 시놀로지 NAS에서의 설치
 
-HA 네이버카페 멀더요원님의 [시놀로지 NAS에 Home Assistant 설치하기](https://cafe.naver.com/koreassistant/95)를 참고하십시오. 
+Synology NAS에서는 Docker를 이용해 설치를 진행합니다. 
 
-<div class='videoWrapper'>
-<iframe width="690" height="437" src="https://www.youtube.com/embed/QdBYUbj0B5Q" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
+[공식문서의 Synology NAS](https://www.home-assistant.io/installation/alternative#synology-nas) 섹션을 참고하십시오.
+
 
 ## 또 다른 방법: 가상 머신에서의 설치 
 


### PR DESCRIPTION
Synology NAS Package Manager를 이용한 설치방법은 21년 1월 15일부로 지원이 중단되었습니다.

Synology DSM package 개발자의 [최신 글](https://community.home-assistant.io/t/home-assistant-supervised-previously-known-as-hass-io-on-synology-dsm-as-native-package-not-supported-or-working-atm/125559)에 따르면, Docker 버전의 문제로 인해 더이상 package manager를 통한 설치는 지원되지 않는다고 합니다. 
> "Due to outdated docker version (and other issues on Synology DSM) is this solution no longer possible to run. Please use the officially supported Docker solution."

현재 이 방법은 공식 문서에서 [Unlisted](https://community.home-assistant.io/t/home-assistant-supervised-previously-known-as-hass-io-on-synology-dsm-as-native-package-not-supported-or-working-atm/125559/1556)되었습니다.

따라서 개발자가 안내한 대로 Docker를 통한 설치방법으로 대체하였습니다.